### PR TITLE
fixing extra spacing in the header when grouping is used

### DIFF
--- a/dist/slick.columngroup.js
+++ b/dist/slick.columngroup.js
@@ -44,7 +44,8 @@
                 left: headerColumns.position().left + "px"
             });
             $groupHeaderColumnsR.css({
-                width: headerColumns.width() + "px",
+			    width: 'auto',
+				position: 'absolute',
                 left: headerColumns.position().left + "px"
             });
 
@@ -75,6 +76,11 @@
             $groupHeaderColumnsR.height(colGroupHeight);
 
             grid.resizeCanvas();
+			
+			 $groupHeaderColumnsR.css({
+                width: headerColumns.width() + "px",
+				position: 'relative'
+            });
         }
 
 

--- a/src/slick.columngroup.js
+++ b/src/slick.columngroup.js
@@ -44,7 +44,8 @@
                 left: headerColumns.position().left + "px"
             });
             $groupHeaderColumnsR.css({
-                width: headerColumns.width() + "px",
+			    width: 'auto',
+				position: 'absolute',
                 left: headerColumns.position().left + "px"
             });
 
@@ -75,6 +76,11 @@
             $groupHeaderColumnsR.height(colGroupHeight);
 
             grid.resizeCanvas();
+			
+			 $groupHeaderColumnsR.css({
+                width: headerColumns.width() + "px",
+				position: 'relative'
+            });
         }
 
 


### PR DESCRIPTION
Problem was that the header container would set it's width before calculating width, so groups were being stuck up vertically instead of horizontally

#2479